### PR TITLE
[feat] #27 빈 입력에 대한 경고 및 헤더,달력ui수정

### DIFF
--- a/src/Calendar.css
+++ b/src/Calendar.css
@@ -1,0 +1,154 @@
+.react-calendar {
+  width: 350px;
+  max-width: 100%;
+  background-color: white;
+  border: 3px solid rgba(84, 141, 84, 0.5);
+  border-radius: 10px;
+  font-family: "Jua", sans-serif;
+  line-height: 1.125em;
+  padding: 1px;
+}
+
+.react-calendar--doubleView {
+  width: 700px;
+}
+
+.react-calendar--doubleView .react-calendar__viewContainer {
+  display: flex;
+  margin: -0.5em;
+}
+
+.react-calendar--doubleView .react-calendar__viewContainer > * {
+  width: 50%;
+  margin: 0.5em;
+}
+
+.react-calendar,
+.react-calendar *,
+.react-calendar *:before,
+.react-calendar *:after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.react-calendar button {
+  margin: 0;
+  border: 0;
+  outline: none;
+}
+
+.react-calendar button:enabled:hover {
+  cursor: pointer;
+}
+
+.react-calendar__navigation {
+  display: flex;
+  height: 44px;
+  margin-bottom: 1em;
+}
+
+.react-calendar__navigation button {
+  min-width: 44px;
+  background: none;
+}
+
+.react-calendar__navigation button:disabled {
+  background-color: #f0f0f0;
+}
+
+.react-calendar__navigation__label {
+  font-family: "Jua", sans-serif;
+
+}
+
+.react-calendar__navigation button:enabled:hover,
+.react-calendar__navigation button:enabled:focus {
+  background-color: #e6e6e6;
+}
+
+.react-calendar__month-view__weekdays {
+  text-align: center;
+  text-transform: uppercase;
+  font: inherit;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+
+.react-calendar__month-view__weekdays__weekday {
+  padding: 0.5em;
+}
+
+.react-calendar__month-view__weekNumbers .react-calendar__tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: inherit;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+
+.react-calendar__month-view__days__day--weekend {
+  color: #d10000;
+}
+
+.react-calendar__month-view__days__day--neighboringMonth {
+  color: #578066;
+}
+
+.react-calendar__year-view .react-calendar__tile,
+.react-calendar__decade-view .react-calendar__tile,
+.react-calendar__century-view .react-calendar__tile {
+  padding: 2em 0.5em;
+}
+
+.react-calendar__tile {
+  max-width: 100%;
+  padding: 10px 6.6667px;
+  background: none;
+  text-align: center;
+  line-height: 16px;
+  font: inherit;
+  font-size: 0.833em;
+}
+
+.react-calendar__tile:disabled {
+  background-color: #f0f0f0;
+}
+
+.react-calendar__tile:enabled:hover,
+.react-calendar__tile:enabled:focus {
+  background-color: #3aff8c;
+}
+
+.react-calendar__tile--now {
+  background: #46c04e;
+}
+
+.react-calendar__tile--now:enabled:hover,
+.react-calendar__tile--now:enabled:focus {
+  background: #017d30;
+}
+
+.react-calendar__tile--hasActive {
+  background: #7aca82;
+}
+
+.react-calendar__tile--hasActive:enabled:hover,
+.react-calendar__tile--hasActive:enabled:focus {
+  background: #7aca82;
+}
+
+.react-calendar__tile--active {
+  background: #7aca82;
+  color: white;
+}
+
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background: #017d30;
+}
+
+.react-calendar--selectRange .react-calendar__tile--hover {
+  background-color: #3aff8c;
+}

--- a/src/components/Admin/AddStudy.js
+++ b/src/components/Admin/AddStudy.js
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import axios from "axios";
 import { useCookies } from "react-cookie";
 
-
 const FormBox = styled.div`
   display: flex;
   flex-direction: column;
@@ -112,7 +111,7 @@ const AddStudy = ({ closeModal }) => {
     meetingDay: "",
     userList: [],
   });
-console.log(formData);
+  console.log(formData);
   useEffect(() => {
     const getUserList = async () => {
       try {
@@ -151,8 +150,24 @@ console.log(formData);
     }
   };
 
+  const selectAll = (e) => {
+    e.preventDefault();
+    const allNames = userList.map((user) => {
+      return user.name;
+    });
+    console.log("allNames는", allNames);
+    setFormData({
+      ...formData,
+      userList: allNames,
+    });
+  };
+
   const addNewStudy = async (e) => {
     e.preventDefault();
+    if (!formData.meetingName || !formData.meetingPlace || !formData.meetingDay || formData.userList.length === 0) {
+      alert("필수 항목을 모두 작성해주세요.");
+      return;
+    }
     try {
       const res = await axios.post("http://3.39.24.69:8080/meeting", formData, {
         headers: {
@@ -166,17 +181,6 @@ console.log(formData);
     }
   };
 
-  const selectAll = (e) => {
-    e.preventDefault();
-    const allNames = userList.map((user) => {
-      return user.name;
-    });
-    console.log("allNames는",allNames);
-    setFormData({
-      ...formData,
-      userList: allNames,
-    });
-  };
   console.log(userList);
   return (
     <FormBox>

--- a/src/components/Admin/ApproveStudy.js
+++ b/src/components/Admin/ApproveStudy.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import moment from "moment";
 import Calendar from "react-calendar";
-import "react-calendar/dist/Calendar.css";
+import "../../Calendar.css";
 import { useCookies } from "react-cookie";
 import styled from "styled-components";
 
@@ -95,9 +95,8 @@ const CalendarBox = styled.div`
   row-gap: 10px;
 `;
 const StyledCalendar = styled(Calendar)`
-   background: white;
-  font-family: "Jua", sans-serif;
-  & .react-calendar__navigation {
+  background: white;
+  /* & .react-calendar__navigation {
     background: rgba(84, 141, 84, 0.5);
     color: white;
   };
@@ -110,7 +109,7 @@ const StyledCalendar = styled(Calendar)`
 };
 & .react-calendar__tile--hasActive {
   background: #5AD18F;
-};
+}; */
 
 `;
 const ApproveStudy = ({ closeModal }) => {
@@ -144,9 +143,6 @@ const ApproveStudy = ({ closeModal }) => {
     };
     getStudyOption();
   }, [token]);
-  
-  console.log("선택한 스터디의 id", selectedStudyId);
-  console.log(meetingDate);
 
   const selectDate = (value) => {
     setFormData({
@@ -172,6 +168,10 @@ const ApproveStudy = ({ closeModal }) => {
 
   const ApproveNewStudy = async (e) => {
     e.preventDefault();
+    if (!formData.content || !formData.meetingId || !formData.meetingDate) {
+      alert("필수 항목을 모두 작성해주세요.");
+      return;
+    }
     try {
       const res = await axios.post(
         `http://3.39.24.69:8080/meeting-weekly`,

--- a/src/components/Admin/AttendanceCheck.js
+++ b/src/components/Admin/AttendanceCheck.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import styled from "styled-components";
 import axios from "axios";
 import { useCookies } from "react-cookie";
-import { useNavigate } from 'react-router-dom';
 
 const FormBox = styled.div`
     display: flex;
@@ -11,32 +10,6 @@ const FormBox = styled.div`
     height: 100%;
 `
 
-const Form = styled.form`
-    display: flex;
-    flex-direction: column;
-    row-gap: 20px;
-`
-
-const Input = styled.input`
-    font-family: "Jua", sans-serif;
-    font-size: 40px;
-    width: 400px;
-    height: 80px;
-    padding-left: 20px;
-    padding-right: 20px;
-    border: none;
-    border-radius: 15px;
-    box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
-`
-
-const ModalFooter = styled.div`
-  display: flex;
-  align-items:center;
-  justify-content: center;
-  column-gap: 120px;
-  width: 80%;
-  height: 15%;
-`;
 const Button = styled.button`
   cursor: pointer;
   font-family: "Jua", sans-serif;
@@ -117,7 +90,6 @@ const AttendanceCheck = ({ closeModal }) => {
     const [showUserList, setShowUserList] = useState(false);
     const [allData, setAllData] = useState([]);
     const token = cookies.token;
-    const navigate = useNavigate();
 
     const selectStudy = (event) => {
         setSelectedStudy(parseInt(event.target.value));

--- a/src/components/Admin/EditStudy.js
+++ b/src/components/Admin/EditStudy.js
@@ -225,6 +225,10 @@ const EditStudy = ({ closeModal }) => {
   console.log("formData는", formData);
   const EditNewStudy = async (e) => {
     e.preventDefault();
+    if (!formData.meetingName || !formData.meetingPlace || !formData.meetingDay || formData.userList.length === 0) {
+      alert("필수 항목을 모두 작성해주세요.");
+      return;
+    }
     try {
       const res = await axios.patch(
         `http://3.39.24.69:8080/meeting/${selectedStudy}`,

--- a/src/components/Admin/InquiryUser.js
+++ b/src/components/Admin/InquiryUser.js
@@ -2,7 +2,6 @@ import React, { useRef, useState } from 'react';
 import styled from "styled-components";
 import axios from "axios";
 import { useCookies } from "react-cookie";
-import { useNavigate } from 'react-router-dom';
 
 const FormBox = styled.div`
     display: flex;
@@ -79,7 +78,6 @@ const InquiryUser = ({ closeModal }) => {
     const [cookies] = useCookies();
     const [showInquiry, setShowInquiry] = useState(false);
     const [userInfo, setUserInfo] = useState({});
-    const navigate = useNavigate();
     const usernameRef = useRef();
     const token = cookies.token;
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,73 +1,109 @@
-import React from 'react';
-import styled from 'styled-components'
+import React from "react";
+import { useCookies } from "react-cookie";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
 
-const Header = ({ leftText, middleText, nickName }) => {
-    const Header = styled.div`
-        display: flex;
-        background-color: rgba(84, 141, 84, .5);
-        box-shadow: 0 0 10px rgba(0, 0, 0, .9);
-        color: rgba(0, 0, 0, .7);
-        justify-content: space-evenly;
-        white-space: nowrap;
-        padding-top: 30px;
-        padding-bottom: 15px;
-        align-items: flex-end;
-        font-weight: 500;
-        font-family: 'Jua', sans-serif;
-        text-align: center;
-    `;
+  const HeaderBox = styled.div`
+    display: flex;
+    background-color: rgba(84, 141, 84, 0.5);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+    color: rgba(0, 0, 0, 0.7);
+    justify-content: space-evenly;
+    white-space: nowrap;
+    padding-top: 30px;
+    padding-bottom: 15px;
+    margin-bottom: 15px;
+    align-items: flex-end;
+    font-weight: 500;
+    font-family: "Jua", sans-serif;
+    text-align: center;
+  `;
 
-    const LeftText = styled.div`
-        font-size: 30px;
-        width: 34%;
-        margin-left: 5%;
+  const LeftText = styled.div`
+    font-size: 35px;
+    width: 40%;
+    margin-left: 5%;
 
-        @media screen and (max-width: 1200px) {
-            width: 100%;
-            margin-left: 0%;
-        }
-    `;
+    @media screen and (max-width: 1200px) {
+      width: 100%;
+      margin-left: 0%;
+    }
+  `;
 
-    const MiddleText = styled.div`
-        font-size: 30px;
-        width: 33%;
+  const MiddleText = styled.div`
+    font-size: 30px;
+    width: 30%;
 
-        @media screen and (max-width: 1200px) {
-            width: 0%;
-            font-size: 0px;
-        }
-    `;
+    @media screen and (max-width: 1200px) {
+      width: 0%;
+      font-size: 0px;
+    }
+  `;
 
-    const NickName = styled.div`
-        font-size: 30px;
-        width: 33%;
-        margin-right: 5%;
+  const NickName = styled.div`
+    font-size: 30px;
+    width: 20%;
+    margin-right: 5%;
 
-        @media screen and (max-width: 1200px) {
-            width: 0%;
-            font-size: 0px;
-            margin-right: 0%;
-        }
-    `;
+    @media screen and (max-width: 1200px) {
+      width: 0%;
+      font-size: 0px;
+      margin-right: 0%;
+    }
+  `;
+  const LogoutButton = styled.button`
+    cursor: pointer;
+    font-family: "Jua", sans-serif;
+    font-size: 25px;
+    width: 10%;
+    border: none;
+    border-radius: 14px;
+    transition: all 1s ease;
+    &:hover {
+        background-color: rgba(84, 141, 84, 0.5);
+        color: black;
+    }
+    margin-right: 30px;
 
-    const Sprout = styled.img`
-        margin-left: 15px;
-        width: 40px;
-    `;
-    return (
-        <Header>
-            <LeftText>
-                {leftText}
-                <Sprout src="images/sprout.png" />
-            </LeftText>
-            <MiddleText>
-                {middleText}
-            </MiddleText>
-            <NickName>
-                {nickName}
-            </NickName>
-        </Header>
-    );
+    @media screen and (max-width: 1200px) {
+      width: 0%;
+      font-size: 0px;
+      margin-right: 0%;
+    }
+  `;
+
+  const Sprout = styled.img`
+    margin-left: 15px;
+    width: 40px;
+  `;
+const Header = ({ leftText}) => {
+  const [cookies, removeAllCookies, removeCookie] = useCookies();
+  const name = cookies.name;
+  const navigate = useNavigate();
+  console.log(cookies);
+  const Logout=()=>{
+    removeCookie('token');
+    removeCookie('name');
+    removeCookie('username');
+    removeCookie('fieldType');
+    removeCookie('roles');
+    removeCookie('message');
+    navigate('/login')
+  }
+console.log(cookies);
+  return (
+    <HeaderBox>
+      <LeftText>
+        {leftText}
+        <Sprout src="images/sprout.png" />
+      </LeftText>
+      <MiddleText></MiddleText>
+      <NickName>
+        {name ? `${name}님의 Garden` : "로그인을 해주세요"}
+      </NickName>
+      {name ? <LogoutButton onClick={Logout}>로그아웃</LogoutButton> : ""}
+    </HeaderBox>
+  );
 };
 
 export default Header;

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import axios from 'axios';
 import moment from 'moment';
-import {useCookie, useCookies} from 'react-cookie';
+import {useCookies} from 'react-cookie';
 
 const Input = styled.input`
     background: transparent;
@@ -70,12 +70,6 @@ const Text = styled.p`
     margin: 0;
     margin-bottom: 20px;
 `
-
-const Image = styled.img`
-    width: 70px;
-    margin-bottom: 20px;
-`;
-
 const SaveUsername = styled.input`
 
 `;
@@ -96,7 +90,7 @@ const LoginForm = () => {
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
 
-    const [cookies, setCookie, removeCookie] = useCookies();
+    const [cookies, setCookie] = useCookies();
 
     const handleSubmit = async (e) => {
         e.preventDefault();

--- a/src/components/TodayList.js
+++ b/src/components/TodayList.js
@@ -21,6 +21,7 @@ const TodayBox = styled.div`
 
 const Title = styled.div`
   margin-left: 30px;
+  margin-top: 20px;
   font-size: 35px;
   font-family: "Jua", sans-serif;
   color: #8c8c8c;

--- a/src/pages/Admin.js
+++ b/src/pages/Admin.js
@@ -25,8 +25,6 @@ const Admin = () => {
     <div>
       <Header
         leftText={"Leets Garden"}
-        middleText={"새싹 키우기"}
-        nickName={"front"}
       />
       <StudyList />
       {windowWidth <= 1200 && (

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -33,7 +33,6 @@ const Login = () => {
     return (
         <div>
             <Header leftText={'Leets Garden'}
-                middleText={'새싹 키우기'}
             />
             <BackGround />
             <StyledLogin>

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -25,8 +25,6 @@ const Main = () => {
     <div>
       <Header
         leftText={"Leets Garden"}
-        middleText={"새싹 키우기"}
-        nickName={"front"}
       />
       <StudyList />
       {windowWidth <= 1200 && (


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
입력을 하지 않고 생성, 수정, 승인 하는 경우에 경고와 함께 기능을 불가하게 만들었습니다. 승인의 달력 헤더의 ui를 수정했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/Leets-Official/Leets-Garden-FE/assets/99270060/7d646068-6b58-426a-80d3-337a17e7ecda)

![image](https://github.com/Leets-Official/Leets-Garden-FE/assets/99270060/8c936816-8cda-4b70-8188-b661c933fad1)

![image](https://github.com/Leets-Official/Leets-Garden-FE/assets/99270060/b53412f5-aea4-493e-9dd5-10dab827d0fa)
<br>

## 4. 완료 사항
1. 달력 색상, 폰트 LeetsGarden의 분위기에 맞게 변경
2. input 입력 안됐을 때 생성, 수정, 승인 기능 막기
3. 헤더 디자인 변경(가운데 텍스트 삭제, 끝에 name추가
4. 헤더의 로그아웃 버튼 추가 로그인 하지 않은 경우 3.의 정보 대신 로그아웃 렌더링
<br>

## 5. 추가해야 할 사항
1. 글꼴 변경
2. 배포 및 연결
3. 맨 처음 보여줄 경로 설정(admin, user)

close #27 