### PR TITLE
[fix] #57 모임수정 기존내용 반영오류 해결

### DIFF
--- a/src/components/Admin/EditStudy.js
+++ b/src/components/Admin/EditStudy.js
@@ -208,10 +208,10 @@ const EditStudy = ({ closeModal }) => {
         );
         setStudyInfo(res.data);
         setFormData({
-          meetingName: res.data.meetingName,
-          meetingPlace: res.data.meetingPlace,
-          meetingDay: res.data.meetingDay,
-          userList: res.data.userList,
+          meetingName: res.data.meetingResponse.meetingName,
+          meetingPlace: res.data.meetingResponse.meetingPlace,
+          meetingDay: res.data.meetingResponse.meetingDay,
+          userList: res.data.meetingResponse.userList,
         });
         console.log(res.data, "이건 해당되는 스터디 정보");
       } catch (error) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
admin기능 중 수정기능에서 기존 모임에 대한 여러 내용을 가져오지 못하는 문제가 있었습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
최민규라는 사용자를 포함시켜 생성, 수정 시 오류가 생겼습니다. 개별 회원조회 시 오류가 발생하는 걸로 보아 db상에서 문제가 있다고 판단해 해당 내용에 대한 조치는 따로 취하지 않았습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/Leets-Official/Leets-Garden-FE/assets/99270060/546688be-cb24-4f4c-b3e0-be45f0b66a17)

<br>

## 4. 완료 사항
모임 클릭시 해당 모임의 정보를 가져와 보여주도록 했습니다.
<br>

## 5. 추가 사항
close #57 